### PR TITLE
fix(ci): Disable Jekyll processing for Doxygen documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,10 +104,12 @@ jobs:
       - name: Install Doxygen
         run: sudo apt-get update && sudo apt-get install -y doxygen graphviz
 
-      - name: Generate documentation
+      - name: Generate Doxygen documentation
         run: |
           cd backend
           doxygen Doxyfile
+          # Disable Jekyll processing for GitHub Pages
+          touch docs/html/.nojekyll
 
       - name: Upload documentation
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add .nojekyll file to prevent GitHub Pages from trying to build Doxygen HTML output with Jekyll, which causes "No such file or directory @ dir_chdir0 - /github/workspace/docs" error.

Fixes: Jekyll conversion error on GitHub Pages deployment