### PR TITLE
feat(audio): add audio input routing and device management

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources(DAWAudioEngine PRIVATE
     src/commands/command-processor.cpp
     src/commands/transport-commands.cpp
     src/commands/project-commands.cpp
+    src/commands/track-commands.cpp
 )
 
 target_include_directories(DAWAudioEngine PRIVATE

--- a/backend/include/audio/audio-engine-core.hpp
+++ b/backend/include/audio/audio-engine-core.hpp
@@ -7,8 +7,11 @@
 #include <juce_core/juce_core.h>
 #include <juce_events/juce_events.h>
 
+#include <atomic>
 #include <memory>
 #include <vector>
+
+#include <nlohmann/json.hpp>
 
 #include "audio/audio-track.hpp"
 #include "audio/beat-track.hpp"
@@ -24,16 +27,19 @@
 // - std::function<void(const String& error)> errorCallback;
 // - void setErrorCallback(std::function<void(const String&)> callback);
 
-class AudioEngineCore : public juce::AudioAppComponent, public juce::Timer {
+class AudioEngineCore : public juce::AudioIODeviceCallback,
+                        public juce::Timer {
  public:
   AudioEngineCore();
   ~AudioEngineCore() override;
 
-  // AudioAppComponent overrides
-  void prepareToPlay(int samplesPerBlockExpected, double sampleRate) override;
-  void getNextAudioBlock(
-      const juce::AudioSourceChannelInfo& bufferToFill) override;
-  void releaseResources() override;
+  // AudioIODeviceCallback overrides
+  void audioDeviceIOCallbackWithContext(
+      const float* const* inputChannelData, int numInputChannels,
+      float* const* outputChannelData, int numOutputChannels, int numSamples,
+      const juce::AudioIODeviceCallbackContext& context) override;
+  void audioDeviceAboutToStart(juce::AudioIODevice* device) override;
+  void audioDeviceStopped() override;
 
   // Song management
   void loadSong(Song* newSong);
@@ -53,24 +59,48 @@ class AudioEngineCore : public juce::AudioAppComponent, public juce::Timer {
   // Timer override (broadcasts transport position to clients)
   void timerCallback() override;
 
+  // Audio devices
+  nlohmann::json getAvailableDevices();
+  nlohmann::json getCurrentDeviceInfo() const;
+  juce::String setAudioDevice(const juce::String& deviceTypeName,
+                              const juce::String& outputDeviceName,
+                              const juce::String& inputDeviceName,
+                              double sampleRate = 0,
+                              int bufferSize = 0);
+
+  // Audio inputs
+  nlohmann::json getAvailableInputs() const;
+  int getNumInputChannels() const;
+  void incrementMonitoringCount();
+  void decrementMonitoringCount();
+
   // WS
   void setWebSocketServer(WebSocketServer* server) { wsServer = server; }
 
  private:
+  juce::AudioDeviceManager deviceManager;
+
   std::atomic<bool> playing;
   float masterVolume;
 
   // Pre-allocated buffers for audio processing (avoid allocations in audio
   // thread)
-  juce::AudioBuffer<float> mixBuffer;  // Stereo mix buffer
-  juce::AudioBuffer<float>
-      trackBuffer;  // Stereo buffer for individual track rendering
+  juce::AudioBuffer<float> mixBuffer;    // Stereo mix buffer
+  juce::AudioBuffer<float> trackBuffer;  // Stereo buffer for individual track rendering
+  juce::AudioBuffer<float> inputBuffer;  // Copy of audio input channels
+
+  std::atomic<int> monitoringTrackCount{0};
 
   Song* activeSong;
   std::atomic<double> playheadPosition;
   std::atomic<double> cursorPosition;
 
   WebSocketServer* wsServer = nullptr;
+
+  // Audio settings persistence
+  void saveSettings();
+  std::unique_ptr<juce::XmlElement> loadSettings();
+  juce::File getSettingsFile() const;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(AudioEngineCore)
 };

--- a/backend/include/audio/audio-file-track.hpp
+++ b/backend/include/audio/audio-file-track.hpp
@@ -21,6 +21,7 @@ class AudioFileTrack : public AudioTrack {
   static std::unique_ptr<AudioFileTrack> fromJson(const nlohmann::json& j);
 
   std::string getTrackType() const override { return "AudioFileTrack"; }
+  void sampleRateChanged() override;
 
  private:
   std::unique_ptr<ClipsManager> clipsManager;

--- a/backend/include/audio/audio-track.hpp
+++ b/backend/include/audio/audio-track.hpp
@@ -3,6 +3,8 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_core/juce_core.h>
 #include <nlohmann/json.hpp>
+
+#include <atomic>
 #include <string>
 
 /**
@@ -90,6 +92,17 @@ class AudioTrack {
    */
   virtual std::string getTrackType() const = 0;
 
+  /** @brief Called when sample rate changes to allow resampling */
+  virtual void sampleRateChanged() {};
+
+  // Input routing
+  void setInputChannel(int channel);
+  int getInputChannel() const;
+  void setInputStereo(bool stereo);
+  bool isInputStereo() const;
+  void setMonitoring(bool enabled);
+  bool isMonitoring() const;
+
   // Getters
   std::string getId() const { return id; }
 
@@ -107,4 +120,13 @@ class AudioTrack {
 
   /** @brief Mute state (true = muted, false = playing) */
   bool mute;
+
+  /** @brief Selected input channel index (-1 = no input) */
+  std::atomic<int> inputChannel{-1};
+
+  /** @brief Input stereo mode (false = mono duplicated, true = stereo pair) */
+  std::atomic<bool> inputStereo{false};
+
+  /** @brief Monitoring state (true = input audio replaces clips) */
+  std::atomic<bool> monitoring{false};
 };

--- a/backend/include/commands/track-commands.hpp
+++ b/backend/include/commands/track-commands.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "commands/command.hpp"
+
+#include <string>
+
+/**
+ * Command to list available audio devices.
+ */
+class ListDevicesCommand : public Command {
+ public:
+  void execute(AppContext& ctx) override;
+};
+
+/**
+ * Command to set the audio input/output device.
+ */
+class SetAudioDeviceCommand : public Command {
+ public:
+  SetAudioDeviceCommand(std::string deviceType, std::string outputDevice,
+                        std::string inputDevice, double sampleRate,
+                        int bufferSize);
+  void execute(AppContext& ctx) override;
+
+ private:
+  std::string deviceType;
+  std::string outputDevice;
+  std::string inputDevice;
+  double sampleRate;
+  int bufferSize;
+};
+
+/**
+ * Command to list available audio input channels.
+ */
+class ListInputsCommand : public Command {
+ public:
+  void execute(AppContext& ctx) override;
+};
+
+/**
+ * Command to set the input channel for a track.
+ */
+class SetTrackInputCommand : public Command {
+ public:
+  SetTrackInputCommand(std::string trackId, int inputChannel, bool stereo);
+  void execute(AppContext& ctx) override;
+
+ private:
+  std::string trackId;
+  int inputChannel;
+  bool stereo;
+};
+
+/**
+ * Command to toggle monitoring on a track.
+ */
+class SetTrackMonitoringCommand : public Command {
+ public:
+  SetTrackMonitoringCommand(std::string trackId, bool monitoring);
+  void execute(AppContext& ctx) override;
+
+ private:
+  std::string trackId;
+  bool monitoring;
+};

--- a/backend/include/model/clips-manager.hpp
+++ b/backend/include/model/clips-manager.hpp
@@ -17,6 +17,7 @@ class ClipsManager {
 
   void renderClips(juce::AudioBuffer<float>& clipBuffer, int numSamples,
                    double currentPosition);
+  void sampleRateChanged();
 
   // Serialization
   nlohmann::json toJson() const;

--- a/backend/include/model/song.hpp
+++ b/backend/include/model/song.hpp
@@ -16,8 +16,9 @@ class Song {
   void removeTrack();
 
   void render(juce::AudioBuffer<float>& mixBuffer,
-              juce::AudioBuffer<float>& trackBuffer, int numSamples,
-              double position);
+              juce::AudioBuffer<float>& trackBuffer,
+              const juce::AudioBuffer<float>& inputBuffer, int numSamples,
+              double position, bool isPlaying);
 
   // Serialization
   nlohmann::json toJson() const;
@@ -25,6 +26,8 @@ class Song {
 
   // Setters / Getters
   std::string getId() const { return id; }
+
+  void sampleRateChanged();
 
   float getTempo() const { return tempo; }
   void setTempo(float newTempo) { tempo = newTempo; }

--- a/backend/include/model/tracks-manager.hpp
+++ b/backend/include/model/tracks-manager.hpp
@@ -16,8 +16,13 @@ class TracksManager {
   void getTrackList();
 
   void renderTracks(juce::AudioBuffer<float>& mixBuffer,
-                    juce::AudioBuffer<float>& trackBuffer, int numSamples,
-                    double currentPosition, float tempo);
+                    juce::AudioBuffer<float>& trackBuffer,
+                    const juce::AudioBuffer<float>& inputBuffer,
+                    int numSamples, double currentPosition, float tempo,
+                    bool isPlaying);
+
+  AudioTrack* findTrackById(const std::string& id) const;
+  void sampleRateChanged();
 
   // Serialization
   nlohmann::json toJson() const;

--- a/backend/src/audio/audio-engine-core.cpp
+++ b/backend/src/audio/audio-engine-core.cpp
@@ -12,40 +12,76 @@ AudioEngineCore::AudioEngineCore()
       cursorPosition(0.0),
       masterVolume(0.5f),
       activeSong(nullptr) {
-  // Audio configuration: 0 inputs, 2 outputs
-  // TODO: [MEDIUM] Add error handling for audio device initialization
-  setAudioChannels(0, 2);
+  auto savedState = loadSettings();
+
+  auto result = deviceManager.initialise(
+      64,                // numInputChannelsNeeded
+      2,                 // numOutputChannelsNeeded
+      savedState.get(),  // savedState (XML) — nullptr if no saved settings
+      true               // selectDefaultDeviceOnFailure
+  );
+
+  if (result.isNotEmpty()) {
+    juce::Logger::writeToLog("Audio device error: " + result);
+  }
+
+  deviceManager.addAudioCallback(this);
 }
 
 AudioEngineCore::~AudioEngineCore() {
   stopTimer();
-  shutdownAudio();
+  deviceManager.removeAudioCallback(this);
+  deviceManager.closeAudioDevice();
 }
 
-void AudioEngineCore::prepareToPlay(int samplesPerBlockExpected,
-                                    double sampleRate) {
+void AudioEngineCore::audioDeviceAboutToStart(juce::AudioIODevice* device) {
+  auto sampleRate = device->getCurrentSampleRate();
+  auto bufferSize = device->getCurrentBufferSizeSamples();
+
   auto& ctx = AudioContext::getInstance();
   ctx.sampleRate = sampleRate;
 
   // Pre-allocate buffers to avoid allocations in audio thread
-  // Allocate for 2 channels (stereo output)
-  mixBuffer.setSize(2, samplesPerBlockExpected, false, true, false);
+  int numActiveInputs = device->getActiveInputChannels().countNumberOfSetBits();
+  mixBuffer.setSize(2, bufferSize, false, true, false);
+  trackBuffer.setSize(2, bufferSize, false, true, false);
+  inputBuffer.setSize(numActiveInputs, bufferSize, false, true, false);
 
-  // Allocate stereo track buffer for individual track rendering
-  trackBuffer.setSize(2, samplesPerBlockExpected, false, true, false);
+  // Reload audio clips if sample rate changed (resampling needed)
+  if (activeSong != nullptr) {
+    activeSong->sampleRateChanged();
+  }
 
   juce::Logger::writeToLog("Audio initialized:");
   juce::Logger::writeToLog(
-      "- Buffer size: " + juce::String(samplesPerBlockExpected) + " samples");
+      "- Buffer size: " + juce::String(bufferSize) + " samples");
   juce::Logger::writeToLog("- Sample rate: " + juce::String(sampleRate) +
                            " Hz");
+  juce::Logger::writeToLog(
+      "- Input channels: " +
+      juce::String(device->getActiveInputChannels().countNumberOfSetBits()));
+  juce::Logger::writeToLog(
+      "- Output channels: " +
+      juce::String(device->getActiveOutputChannels().countNumberOfSetBits()));
   juce::Logger::writeToLog("- Ready to play!");
+}
+
+void AudioEngineCore::audioDeviceStopped() {
+  juce::Logger::writeToLog("Audio device stopped");
 }
 
 void AudioEngineCore::loadSong(Song* newSong) {
   activeSong = newSong;
   playheadPosition.store(0, std::memory_order_relaxed);
   cursorPosition.store(0, std::memory_order_relaxed);
+
+  // Sync monitoring counter with tracks loaded from JSON
+  int count = 0;
+  for (const auto& track : activeSong->getTracksManager()->getTracks()) {
+    if (track->isMonitoring()) ++count;
+  }
+  monitoringTrackCount.store(count, std::memory_order_relaxed);
+
   juce::Logger::writeToLog("[AudioEngine] song loaded");
 
   if (wsServer != nullptr) {
@@ -199,37 +235,57 @@ void AudioEngineCore::setCursorPosition(double position) {
   }
 }
 
-void AudioEngineCore::getNextAudioBlock(
-    const juce::AudioSourceChannelInfo& bufferToFill) {
-  auto* buffer = bufferToFill.buffer;
-  auto numSamples = bufferToFill.numSamples;
+void AudioEngineCore::audioDeviceIOCallbackWithContext(
+    const float* const* inputChannelData, int numInputChannels,
+    float* const* outputChannelData, int numOutputChannels, int numSamples,
+    const juce::AudioIODeviceCallbackContext& /*context*/) {
+  // Copy real input channels to pre-allocated inputBuffer
+  int channelsToCopy = std::min(numInputChannels, inputBuffer.getNumChannels());
+  for (int ch = 0; ch < channelsToCopy; ++ch) {
+    if (inputChannelData[ch] != nullptr) {
+      inputBuffer.copyFrom(ch, 0, inputChannelData[ch], numSamples);
+    }
+  }
 
-  if (!playing || !activeSong) {
-    buffer->clear();
+  bool hasMonitoring =
+      monitoringTrackCount.load(std::memory_order_relaxed) > 0;
+
+  if ((!playing && !hasMonitoring) || !activeSong) {
+    // Clear output
+    for (int ch = 0; ch < numOutputChannels; ++ch) {
+      juce::FloatVectorOperations::clear(outputChannelData[ch], numSamples);
+    }
     return;
   }
 
   // Clear the pre-allocated mix buffer
   mixBuffer.clear();
 
-  // Render song
-  activeSong->render(mixBuffer, trackBuffer, numSamples,
-                     playheadPosition.load(std::memory_order_relaxed));
+  bool isPlaying = playing.load(std::memory_order_relaxed);
 
-  auto const& ctx = AudioContext::getInstance();
+  // Render song with input buffer for monitoring
+  activeSong->render(mixBuffer, trackBuffer, inputBuffer, numSamples,
+                     playheadPosition.load(std::memory_order_relaxed),
+                     isPlaying);
 
-  playheadPosition.store(playheadPosition + (double)numSamples / ctx.sampleRate,
-                         std::memory_order_relaxed);
+  if (isPlaying) {
+    auto const& ctx = AudioContext::getInstance();
+    playheadPosition.store(
+        playheadPosition + (double)numSamples / ctx.sampleRate,
+        std::memory_order_relaxed);
+  }
 
-  // Apply master volume to mixed buffer using SIMD-optimized operation
+  // Apply master volume to mixed buffer
   for (int channel = 0; channel < mixBuffer.getNumChannels(); ++channel) {
     mixBuffer.applyGain(channel, 0, numSamples, masterVolume);
   }
 
-  // Copy from mix buffer to output buffer
-  for (int channel = 0; channel < buffer->getNumChannels(); ++channel) {
-    buffer->copyFrom(channel, bufferToFill.startSample, mixBuffer, channel, 0,
-                     numSamples);
+  // Copy from mix buffer to output channel pointers
+  for (int ch = 0; ch < numOutputChannels; ++ch) {
+    int srcCh = std::min(ch, mixBuffer.getNumChannels() - 1);
+    juce::FloatVectorOperations::copy(outputChannelData[ch],
+                                      mixBuffer.getReadPointer(srcCh),
+                                      numSamples);
   }
 }
 
@@ -244,6 +300,182 @@ void AudioEngineCore::timerCallback() {
   wsServer->broadcast(msg.dump());
 }
 
-void AudioEngineCore::releaseResources() {
-  juce::Logger::writeToLog("Releasing audio resources");
+nlohmann::json AudioEngineCore::getAvailableDevices() {
+  nlohmann::json result;
+  result["deviceTypes"] = nlohmann::json::array();
+
+  for (auto* type : deviceManager.getAvailableDeviceTypes()) {
+    nlohmann::json deviceType;
+    deviceType["name"] = type->getTypeName().toStdString();
+    deviceType["outputDevices"] = nlohmann::json::array();
+    deviceType["inputDevices"] = nlohmann::json::array();
+
+    auto outputNames = type->getDeviceNames(false);
+    for (auto& name : outputNames) {
+      deviceType["outputDevices"].push_back(name.toStdString());
+    }
+
+    auto inputNames = type->getDeviceNames(true);
+    for (auto& name : inputNames) {
+      deviceType["inputDevices"].push_back(name.toStdString());
+    }
+
+    result["deviceTypes"].push_back(deviceType);
+  }
+
+  // Current device info
+  auto* currentDevice = deviceManager.getCurrentAudioDevice();
+  if (currentDevice != nullptr) {
+    auto setup = deviceManager.getAudioDeviceSetup();
+
+    nlohmann::json availableSampleRates = nlohmann::json::array();
+    for (auto rate : currentDevice->getAvailableSampleRates()) {
+      availableSampleRates.push_back(rate);
+    }
+
+    nlohmann::json availableBufferSizes = nlohmann::json::array();
+    for (auto size : currentDevice->getAvailableBufferSizes()) {
+      availableBufferSizes.push_back(size);
+    }
+
+    result["current"] = {
+        {"deviceType", currentDevice->getTypeName().toStdString()},
+        {"outputDevice", setup.outputDeviceName.toStdString()},
+        {"inputDevice", setup.inputDeviceName.toStdString()},
+        {"sampleRate", currentDevice->getCurrentSampleRate()},
+        {"bufferSize", currentDevice->getCurrentBufferSizeSamples()},
+        {"availableSampleRates", availableSampleRates},
+        {"availableBufferSizes", availableBufferSizes}};
+  }
+
+  return result;
+}
+
+nlohmann::json AudioEngineCore::getCurrentDeviceInfo() const {
+  nlohmann::json result;
+  auto* device = deviceManager.getCurrentAudioDevice();
+  if (device != nullptr) {
+    auto setup = deviceManager.getAudioDeviceSetup();
+    result["deviceType"] = device->getTypeName().toStdString();
+    result["outputDevice"] = setup.outputDeviceName.toStdString();
+    result["inputDevice"] = setup.inputDeviceName.toStdString();
+    result["sampleRate"] = device->getCurrentSampleRate();
+    result["bufferSize"] = device->getCurrentBufferSizeSamples();
+
+    nlohmann::json availableSampleRates = nlohmann::json::array();
+    for (auto rate : device->getAvailableSampleRates()) {
+      availableSampleRates.push_back(rate);
+    }
+    result["availableSampleRates"] = availableSampleRates;
+
+    nlohmann::json availableBufferSizes = nlohmann::json::array();
+    for (auto size : device->getAvailableBufferSizes()) {
+      availableBufferSizes.push_back(size);
+    }
+    result["availableBufferSizes"] = availableBufferSizes;
+  }
+  return result;
+}
+
+juce::String AudioEngineCore::setAudioDevice(
+    const juce::String& deviceTypeName, const juce::String& outputDeviceName,
+    const juce::String& inputDeviceName, double sampleRate, int bufferSize) {
+  // Set the device type first so the setup applies to the correct driver
+  if (deviceTypeName.isNotEmpty()) {
+    deviceManager.setCurrentAudioDeviceType(deviceTypeName, true);
+  }
+
+  auto setup = deviceManager.getAudioDeviceSetup();
+  setup.outputDeviceName = outputDeviceName;
+  setup.inputDeviceName = inputDeviceName;
+
+  // Set sample rate if specified, otherwise keep current
+  if (sampleRate > 0) {
+    setup.sampleRate = sampleRate;
+  }
+
+  // Set buffer size if specified, otherwise keep current
+  if (bufferSize > 0) {
+    setup.bufferSize = bufferSize;
+  }
+
+  // Enable all input channels — JUCE will cap at the device's actual maximum
+  setup.inputChannels.setRange(0, 64, true);
+  setup.useDefaultInputChannels = false;
+
+  auto error = deviceManager.setAudioDeviceSetup(setup, true);
+
+  if (error.isEmpty()) {
+    saveSettings();
+  }
+
+  return error;
+}
+
+nlohmann::json AudioEngineCore::getAvailableInputs() const {
+  nlohmann::json inputs = nlohmann::json::array();
+
+  auto* device = deviceManager.getCurrentAudioDevice();
+  if (device != nullptr) {
+    auto channelNames = device->getInputChannelNames();
+    auto activeChannels = device->getActiveInputChannels();
+
+    for (int i = 0; i < channelNames.size(); ++i) {
+      if (activeChannels[i]) {
+        nlohmann::json input;
+        input["index"] = i;
+        input["name"] = channelNames[i].toStdString();
+        inputs.push_back(input);
+      }
+    }
+  }
+
+  return inputs;
+}
+
+int AudioEngineCore::getNumInputChannels() const {
+  auto* device = deviceManager.getCurrentAudioDevice();
+  if (device != nullptr) {
+    return device->getActiveInputChannels().countNumberOfSetBits();
+  }
+  return 0;
+}
+
+void AudioEngineCore::incrementMonitoringCount() {
+  monitoringTrackCount.fetch_add(1, std::memory_order_relaxed);
+}
+
+void AudioEngineCore::decrementMonitoringCount() {
+  monitoringTrackCount.fetch_sub(1, std::memory_order_relaxed);
+}
+
+juce::File AudioEngineCore::getSettingsFile() const {
+  return juce::File::getSpecialLocation(
+             juce::File::userApplicationDataDirectory)
+      .getChildFile("DAWAudioEngine")
+      .getChildFile("audio-settings.xml");
+}
+
+void AudioEngineCore::saveSettings() {
+  auto xml = deviceManager.createStateXml();
+  if (xml == nullptr) return;
+
+  auto file = getSettingsFile();
+  file.getParentDirectory().createDirectory();
+  xml->writeTo(file);
+
+  juce::Logger::writeToLog("[AudioEngine] Settings saved to " +
+                           file.getFullPathName());
+}
+
+std::unique_ptr<juce::XmlElement> AudioEngineCore::loadSettings() {
+  auto file = getSettingsFile();
+  if (!file.existsAsFile()) return nullptr;
+
+  auto xml = juce::XmlDocument::parse(file);
+  if (xml != nullptr) {
+    juce::Logger::writeToLog("[AudioEngine] Settings loaded from " +
+                             file.getFullPathName());
+  }
+  return xml;
 }

--- a/backend/src/audio/audio-file-track.cpp
+++ b/backend/src/audio/audio-file-track.cpp
@@ -34,6 +34,10 @@ void AudioFileTrack::renderBlock(juce::AudioBuffer<float>& buffer,
   }
 }
 
+void AudioFileTrack::sampleRateChanged() {
+  clipsManager->sampleRateChanged();
+}
+
 nlohmann::json AudioFileTrack::toJson() const {
   nlohmann::json j;
   j["type"] = getTrackType();
@@ -43,6 +47,9 @@ nlohmann::json AudioFileTrack::toJson() const {
   j["pan"] = pan;
   j["mute"] = mute;
   j["clips"] = clipsManager->toJson();
+  j["inputChannel"] = inputChannel.load(std::memory_order_relaxed);
+  j["inputStereo"] = inputStereo.load(std::memory_order_relaxed);
+  j["monitoring"] = monitoring.load(std::memory_order_relaxed);
   return j;
 }
 
@@ -59,6 +66,9 @@ std::unique_ptr<AudioFileTrack> AudioFileTrack::fromJson(
   track->volume = j.value("volume", 0.4f);
   track->pan = j.value("pan", 0.0f);
   track->mute = j.value("mute", false);
+  track->inputChannel.store(j.value("inputChannel", -1), std::memory_order_relaxed);
+  track->inputStereo.store(j.value("inputStereo", false), std::memory_order_relaxed);
+  track->monitoring.store(j.value("monitoring", false), std::memory_order_relaxed);
 
   // Load clips
   if (j.contains("clips")) {

--- a/backend/src/audio/audio-track.cpp
+++ b/backend/src/audio/audio-track.cpp
@@ -14,3 +14,27 @@ void AudioTrack::setMute(bool shouldMute) {
 void AudioTrack::setVolume(float newVolume) {
   this->volume = juce::jlimit(0.0f, 1.0f, newVolume);
 }
+
+void AudioTrack::setInputChannel(int channel) {
+  inputChannel.store(channel, std::memory_order_relaxed);
+}
+
+int AudioTrack::getInputChannel() const {
+  return inputChannel.load(std::memory_order_relaxed);
+}
+
+void AudioTrack::setInputStereo(bool stereo) {
+  inputStereo.store(stereo, std::memory_order_relaxed);
+}
+
+bool AudioTrack::isInputStereo() const {
+  return inputStereo.load(std::memory_order_relaxed);
+}
+
+void AudioTrack::setMonitoring(bool enabled) {
+  monitoring.store(enabled, std::memory_order_relaxed);
+}
+
+bool AudioTrack::isMonitoring() const {
+  return monitoring.load(std::memory_order_relaxed);
+}

--- a/backend/src/audio/beat-track.cpp
+++ b/backend/src/audio/beat-track.cpp
@@ -116,6 +116,9 @@ nlohmann::json BeatTrack::toJson() const {
   j["pan"] = pan;
   j["mute"] = mute;
   j["frequency"] = frequency;
+  j["inputChannel"] = inputChannel.load(std::memory_order_relaxed);
+  j["inputStereo"] = inputStereo.load(std::memory_order_relaxed);
+  j["monitoring"] = monitoring.load(std::memory_order_relaxed);
   return j;
 }
 
@@ -132,6 +135,9 @@ std::unique_ptr<BeatTrack> BeatTrack::fromJson(const nlohmann::json& j) {
   track->volume = j.value("volume", 0.4f);
   track->pan = j.value("pan", 0.0f);
   track->mute = j.value("mute", false);
+  track->inputChannel.store(j.value("inputChannel", -1), std::memory_order_relaxed);
+  track->inputStereo.store(j.value("inputStereo", false), std::memory_order_relaxed);
+  track->monitoring.store(j.value("monitoring", false), std::memory_order_relaxed);
 
   return track;
 }

--- a/backend/src/commands/track-commands.cpp
+++ b/backend/src/commands/track-commands.cpp
@@ -1,0 +1,154 @@
+#include "commands/track-commands.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include "app-context.hpp"
+#include "audio/audio-engine-core.hpp"
+#include "commands/command-factory.hpp"
+#include "model/song.hpp"
+
+void ListDevicesCommand::execute(AppContext& ctx) {
+  nlohmann::json response;
+  response["type"] = "response";
+  response["event"] = "audio.devicesList";
+  auto devices = ctx.getAudioEngine().getAvailableDevices();
+  response["deviceTypes"] = devices["deviceTypes"];
+  if (devices.contains("current")) {
+    response["current"] = devices["current"];
+  }
+  reply(response.dump());
+}
+
+SetAudioDeviceCommand::SetAudioDeviceCommand(std::string deviceType,
+                                             std::string outputDevice,
+                                             std::string inputDevice,
+                                             double sampleRate,
+                                             int bufferSize)
+    : deviceType(std::move(deviceType)),
+      outputDevice(std::move(outputDevice)),
+      inputDevice(std::move(inputDevice)),
+      sampleRate(sampleRate),
+      bufferSize(bufferSize) {}
+
+void SetAudioDeviceCommand::execute(AppContext& ctx) {
+  auto result = ctx.getAudioEngine().setAudioDevice(
+      juce::String(deviceType), juce::String(outputDevice),
+      juce::String(inputDevice), sampleRate, bufferSize);
+
+  nlohmann::json response;
+  response["type"] = "broadcast";
+  response["event"] = "audio.deviceChanged";
+  response["current"] = ctx.getAudioEngine().getCurrentDeviceInfo();
+
+  if (result.isNotEmpty()) {
+    response["error"] = result.toStdString();
+  }
+
+  ctx.getWebSocketServer().broadcast(response.dump());
+
+  // Also broadcast updated input list since channels may have changed
+  nlohmann::json inputsMsg;
+  inputsMsg["type"] = "broadcast";
+  inputsMsg["event"] = "audio.inputsList";
+  inputsMsg["inputs"] = ctx.getAudioEngine().getAvailableInputs();
+  ctx.getWebSocketServer().broadcast(inputsMsg.dump());
+}
+
+void ListInputsCommand::execute(AppContext& ctx) {
+  nlohmann::json response;
+  response["type"] = "response";
+  response["event"] = "audio.inputsList";
+  response["inputs"] = ctx.getAudioEngine().getAvailableInputs();
+  reply(response.dump());
+}
+
+SetTrackInputCommand::SetTrackInputCommand(std::string trackId,
+                                           int inputChannel, bool stereo)
+    : trackId(std::move(trackId)),
+      inputChannel(inputChannel),
+      stereo(stereo) {}
+
+void SetTrackInputCommand::execute(AppContext& ctx) {
+  auto* song = ctx.getAudioEngine().getActiveSong();
+  if (!song) return;
+
+  auto* track = song->getTracksManager()->findTrackById(trackId);
+  if (!track) return;
+
+  track->setInputChannel(inputChannel);
+  track->setInputStereo(stereo);
+
+  nlohmann::json broadcast;
+  broadcast["type"] = "broadcast";
+  broadcast["event"] = "track.inputChanged";
+  broadcast["trackId"] = trackId;
+  broadcast["inputChannel"] = inputChannel;
+  broadcast["stereo"] = stereo;
+  ctx.getWebSocketServer().broadcast(broadcast.dump());
+}
+
+SetTrackMonitoringCommand::SetTrackMonitoringCommand(std::string trackId,
+                                                     bool monitoring)
+    : trackId(std::move(trackId)), monitoring(monitoring) {}
+
+void SetTrackMonitoringCommand::execute(AppContext& ctx) {
+  auto* song = ctx.getAudioEngine().getActiveSong();
+  if (!song) return;
+
+  auto* track = song->getTracksManager()->findTrackById(trackId);
+  if (!track) return;
+
+  bool wasMonitoring = track->isMonitoring();
+  if (wasMonitoring == monitoring) return;
+
+  track->setMonitoring(monitoring);
+
+  if (monitoring) {
+    ctx.getAudioEngine().incrementMonitoringCount();
+  } else {
+    ctx.getAudioEngine().decrementMonitoringCount();
+  }
+
+  nlohmann::json broadcast;
+  broadcast["type"] = "broadcast";
+  broadcast["event"] = "track.monitoringChanged";
+  broadcast["trackId"] = trackId;
+  broadcast["monitoring"] = monitoring;
+  ctx.getWebSocketServer().broadcast(broadcast.dump());
+}
+
+// Auto-registration
+REGISTER_COMMAND("audio.listDevices", ListDevicesCommand);
+
+REGISTER_COMMAND_WITH_CREATOR(
+    "audio.setDevice", SetAudioDevice,
+    [](const nlohmann::json& payload) -> CommandPtr {
+      return std::make_unique<SetAudioDeviceCommand>(
+          payload.value("deviceType", ""),
+          payload.value("outputDevice", ""),
+          payload.value("inputDevice", ""),
+          payload.value("sampleRate", 0.0),
+          payload.value("bufferSize", 0));
+    });
+
+REGISTER_COMMAND("audio.listInputs", ListInputsCommand);
+
+REGISTER_COMMAND_WITH_CREATOR(
+    "track.setInput", SetTrackInput,
+    [](const nlohmann::json& payload) -> CommandPtr {
+      std::string trackId = payload.value("trackId", "");
+      if (trackId.empty()) return nullptr;
+      int inputChannel = payload.value("inputChannel", -1);
+      bool stereo = payload.value("stereo", false);
+      return std::make_unique<SetTrackInputCommand>(trackId, inputChannel,
+                                                    stereo);
+    });
+
+REGISTER_COMMAND_WITH_CREATOR(
+    "track.setMonitoring", SetTrackMonitoring,
+    [](const nlohmann::json& payload) -> CommandPtr {
+      std::string trackId = payload.value("trackId", "");
+      if (trackId.empty()) return nullptr;
+      bool monitoring = payload.value("monitoring", false);
+      return std::make_unique<SetTrackMonitoringCommand>(trackId, monitoring);
+    });

--- a/backend/src/services/clips-manager.cpp
+++ b/backend/src/services/clips-manager.cpp
@@ -20,6 +20,12 @@ void ClipsManager::renderClips(juce::AudioBuffer<float>& clipBuffer,
   }
 }
 
+void ClipsManager::sampleRateChanged() {
+  for (auto& clip : clips) {
+    clip->loadAudioFile();
+  }
+}
+
 nlohmann::json ClipsManager::toJson() const {
   nlohmann::json j = nlohmann::json::array();
 

--- a/backend/src/services/song.cpp
+++ b/backend/src/services/song.cpp
@@ -18,12 +18,15 @@ void Song::removeTrack() {
 }
 
 void Song::render(juce::AudioBuffer<float>& mixBuffer,
-                  juce::AudioBuffer<float>& trackBuffer, int numSamples,
-                  double pos) {
-  // double pos = currentPosition.load(std::memory_order_relaxed);
-  tracksManager->renderTracks(mixBuffer, trackBuffer, numSamples, pos, tempo);
+                  juce::AudioBuffer<float>& trackBuffer,
+                  const juce::AudioBuffer<float>& inputBuffer, int numSamples,
+                  double pos, bool isPlaying) {
+  tracksManager->renderTracks(mixBuffer, trackBuffer, inputBuffer, numSamples,
+                              pos, tempo, isPlaying);
+}
 
-  auto const& ctx = AudioContext::getInstance();
+void Song::sampleRateChanged() {
+  tracksManager->sampleRateChanged();
 }
 
 nlohmann::json Song::toJson() const {

--- a/backend/src/services/tracks-manager.cpp
+++ b/backend/src/services/tracks-manager.cpp
@@ -3,6 +3,17 @@
 #include "audio/audio-file-track.hpp"
 #include "audio/beat-track.hpp"
 
+#include <cmath>
+
+namespace {
+/** @brief Equal-power panning: compute left/right gains from pan in [-1, 1] */
+inline std::pair<float, float> computePanGains(float pan) {
+  float angle = (pan + 1.0f) * 0.25f *
+                juce::MathConstants<float>::pi;  // 0..π/2
+  return {std::cos(angle), std::sin(angle)};
+}
+}  // namespace
+
 TracksManager::TracksManager() = default;
 TracksManager::~TracksManager() = default;
 
@@ -16,14 +27,45 @@ void TracksManager::removeTrack() {
 
 void TracksManager::renderTracks(juce::AudioBuffer<float>& mixBuffer,
                                  juce::AudioBuffer<float>& trackBuffer,
+                                 const juce::AudioBuffer<float>& inputBuffer,
                                  int numSamples, double currentPosition,
-                                 float tempo) {
+                                 float tempo, bool isPlaying) {
   for (size_t trackIdx = 0; trackIdx < tracks.size(); ++trackIdx) {
     trackBuffer.clear();
 
     if (!tracks[trackIdx]->mute) {
-      tracks[trackIdx]->renderBlock(trackBuffer, 0, numSamples, currentPosition,
-                                    tempo);
+      int inCh = tracks[trackIdx]->getInputChannel();
+      bool shouldMonitor = tracks[trackIdx]->isMonitoring() && inCh >= 0 &&
+                           inCh < inputBuffer.getNumChannels();
+
+      if (shouldMonitor) {
+        // Route input audio to track instead of rendering clips
+        if (tracks[trackIdx]->isInputStereo()) {
+          trackBuffer.copyFrom(0, 0, inputBuffer, inCh, 0, numSamples);
+          int rightCh =
+              std::min(inCh + 1, inputBuffer.getNumChannels() - 1);
+          trackBuffer.copyFrom(1, 0, inputBuffer, rightCh, 0, numSamples);
+        } else {
+          // Mono: duplicate to both channels
+          trackBuffer.copyFrom(0, 0, inputBuffer, inCh, 0, numSamples);
+          trackBuffer.copyFrom(1, 0, inputBuffer, inCh, 0, numSamples);
+        }
+        // Apply track volume
+        for (int ch = 0; ch < trackBuffer.getNumChannels(); ++ch) {
+          trackBuffer.applyGain(ch, 0, numSamples, tracks[trackIdx]->volume);
+        }
+      } else if (isPlaying) {
+        // Only render clips/synth when transport is running
+        tracks[trackIdx]->renderBlock(trackBuffer, 0, numSamples,
+                                      currentPosition, tempo);
+      }
+    }
+
+    // Apply equal-power panning
+    if (trackBuffer.getNumChannels() >= 2) {
+      auto [gainL, gainR] = computePanGains(tracks[trackIdx]->pan);
+      trackBuffer.applyGain(0, 0, numSamples, gainL);
+      trackBuffer.applyGain(1, 0, numSamples, gainR);
     }
 
     for (int channel = 0; channel < mixBuffer.getNumChannels(); ++channel) {
@@ -31,6 +73,21 @@ void TracksManager::renderTracks(juce::AudioBuffer<float>& mixBuffer,
       mixBuffer.addFrom(channel, 0, trackBuffer, srcChannel, 0, numSamples);
     }
   }
+}
+
+void TracksManager::sampleRateChanged() {
+  for (auto& track : tracks) {
+    track->sampleRateChanged();
+  }
+}
+
+AudioTrack* TracksManager::findTrackById(const std::string& id) const {
+  for (const auto& track : tracks) {
+    if (track->getId() == id) {
+      return track.get();
+    }
+  }
+  return nullptr;
 }
 
 nlohmann::json TracksManager::toJson() const {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,17 +4,20 @@ import HomePage from './pages/HomePage'
 import { WebSocketProvider } from './shared/contexts/websocket-provider'
 import { ProjectsProvider } from './shared/contexts/projects-provider'
 import { ProjectProvider } from './shared/contexts/project-provider'
+import { AudioDevicesProvider } from './shared/contexts/audio-devices-provider'
 
 function App() {
   return (
     <WebSocketProvider>
-      <ProjectsProvider>
-        <ProjectProvider>
-          <Routes>
-            <Route index element={<HomePage />} />
-          </Routes>
-        </ProjectProvider>
-      </ProjectsProvider>
+      <AudioDevicesProvider>
+        <ProjectsProvider>
+          <ProjectProvider>
+            <Routes>
+              <Route index element={<HomePage />} />
+            </Routes>
+          </ProjectProvider>
+        </ProjectsProvider>
+      </AudioDevicesProvider>
     </WebSocketProvider>
   )
 }

--- a/frontend/src/features/audio-settings/components/AudioSettingsDialog.tsx
+++ b/frontend/src/features/audio-settings/components/AudioSettingsDialog.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import { useAudioDevices } from '@/shared/contexts/audio-devices-provider'
+import { Button } from '@/shared/shadcn/components/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shared/shadcn/components/dialog'
+import { IconSettings } from '@tabler/icons-react'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/shadcn/components/select'
+import { Label } from '@/shared/shadcn/components/label'
+
+export function AudioSettingsDialog() {
+  const { deviceTypes, currentDevice, setAudioDevice, fetchDevices } =
+    useAudioDevices()
+  const [open, setOpen] = useState(false)
+
+  const currentType = deviceTypes.find(
+    (dt) => dt.name === currentDevice?.deviceType,
+  )
+
+  function handleInputChange(inputDevice: string) {
+    if (!currentDevice) return
+    setAudioDevice(
+      currentDevice.deviceType,
+      currentDevice.outputDevice,
+      inputDevice,
+    )
+  }
+
+  function handleOutputChange(outputDevice: string) {
+    if (!currentDevice) return
+    setAudioDevice(
+      currentDevice.deviceType,
+      outputDevice,
+      currentDevice.inputDevice,
+    )
+  }
+
+  function handleSampleRateChange(value: string) {
+    if (!currentDevice) return
+    setAudioDevice(
+      currentDevice.deviceType,
+      currentDevice.outputDevice,
+      currentDevice.inputDevice,
+      Number(value),
+    )
+  }
+
+  function handleBufferSizeChange(value: string) {
+    if (!currentDevice) return
+    setAudioDevice(
+      currentDevice.deviceType,
+      currentDevice.outputDevice,
+      currentDevice.inputDevice,
+      undefined,
+      Number(value),
+    )
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v)
+        if (v) fetchDevices()
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="icon-sm" title="Audio settings">
+          <IconSettings size={16} />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Audio Settings</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-row justify-between">
+            {currentDevice?.availableSampleRates?.length &&
+              currentDevice.availableSampleRates.length > 0 && (
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs font-medium">Sample Rate</Label>
+                  <Select
+                    onValueChange={handleSampleRateChange}
+                    value={String(currentDevice.sampleRate)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Sample Rate" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {currentDevice.availableSampleRates.map((rate) => (
+                        <SelectItem key={rate} value={String(rate)}>
+                          {rate >= 1000 ? `${rate / 1000} kHz` : `${rate} Hz`}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
+            {currentDevice?.availableBufferSizes?.length &&
+              currentDevice.availableBufferSizes.length > 0 && (
+                <div className="flex flex-col gap-1">
+                  <Label className="text-xs font-medium">Buffer Size</Label>
+                  <Select
+                    onValueChange={handleBufferSizeChange}
+                    value={String(currentDevice.bufferSize)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Buffer Size" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {currentDevice.availableBufferSizes.map((size) => (
+                        <SelectItem key={size} value={String(size)}>
+                          {size} samples
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs font-medium">Output Device</Label>
+            <Select
+              onValueChange={handleOutputChange}
+              value={currentDevice?.outputDevice}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Output Device" />
+              </SelectTrigger>
+              <SelectContent>
+                {currentType?.outputDevices.map((name) => (
+                  <SelectItem key={name} value={name}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label className="text-xs font-medium">Input Device</Label>
+            <Select
+              onValueChange={handleInputChange}
+              value={currentDevice?.inputDevice}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Input Device" className="w-full" />
+              </SelectTrigger>
+              <SelectContent>
+                {currentType?.inputDevices.map((name) => (
+                  <SelectItem key={name} value={name}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/navbar/components/Navbar.tsx
+++ b/frontend/src/features/navbar/components/Navbar.tsx
@@ -5,6 +5,7 @@ import { useProject } from '@/shared/contexts/project-provider'
 import { useEffect, useState } from 'react'
 import { Song } from '@/shared/models/song'
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react'
+import { AudioSettingsDialog } from '@/features/audio-settings/components/AudioSettingsDialog'
 
 function Navbar() {
   const { isConnected, send } = useWebSocket()
@@ -65,14 +66,17 @@ function Navbar() {
         )}
       </div>
 
-      <div className="absolute right-4 text-xs flex items-center gap-2 w-min">
-        <div
-          className={cn(
-            'rounded-full size-2.5',
-            isConnected ? 'bg-chart-4' : 'bg-gray-500',
-          )}
-        />
-        {isConnected ? 'Connected' : 'Disconnected'}
+      <div className="absolute right-4 text-xs flex items-center gap-3">
+        <AudioSettingsDialog />
+        <div className="flex items-center gap-2">
+          <div
+            className={cn(
+              'rounded-full size-2.5',
+              isConnected ? 'bg-chart-4' : 'bg-gray-500',
+            )}
+          />
+          {isConnected ? 'Connected' : 'Disconnected'}
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/features/sequencer/components/Sequencer.tsx
+++ b/frontend/src/features/sequencer/components/Sequencer.tsx
@@ -1,21 +1,35 @@
 import { useProject } from '@/shared/contexts/project-provider'
 import { Transport } from '../../transport/components/Transport'
 import Track from './Track'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Timeline from './Timeline'
 import { useSequencer } from '../hooks/useSequencer'
 import { useWebSocket } from '@/shared/contexts/websocket-provider'
 
 function Sequencer() {
-  const { project, playing, activeSong, cursorPos, trackViews } = useProject()
+  const {
+    project,
+    playing,
+    activeSong,
+    cursorPos,
+    trackViews,
+    availableInputs,
+    setTrackInput,
+    setTrackMonitoring,
+  } = useProject()
   const { send } = useWebSocket()
   const [zoom, setZoom] = useState(1)
   const [scrollX, setScrollX] = useState(0)
-  const { draw } = useSequencer(zoom, scrollX)
+  const [scrollY, setScrollY] = useState(0)
+  const { draw } = useSequencer(zoom, scrollX, scrollY)
+
+  const tracksContainer = useRef<HTMLDivElement>(null)
+  const isProgrammaticScroll = useRef(false)
 
   const handleWheel = useCallback(
     (e: WheelEvent) => {
       e.preventDefault()
+
       if (e.shiftKey) {
         const scrollDelta = e.deltaY > 0 ? 50 : -50
         setScrollX((prev) => Math.max(0, prev + scrollDelta))
@@ -38,6 +52,15 @@ function Sequencer() {
           })
           return newZoom
         })
+      } else {
+        const scrollDelta = e.deltaY > 0 ? 50 : -50
+        const maxScrollY = tracksContainer.current
+          ? tracksContainer.current.scrollHeight -
+            tracksContainer.current.clientHeight
+          : 0
+        setScrollY((prev) =>
+          Math.max(0, Math.min(maxScrollY, prev + scrollDelta)),
+        )
       }
     },
     [cursorPos, activeSong],
@@ -91,6 +114,26 @@ function Sequencer() {
   )
 
   useEffect(() => {
+    if (!tracksContainer.current) return
+    isProgrammaticScroll.current = true
+    tracksContainer.current.scrollTo({ top: scrollY, behavior: 'instant' })
+  }, [scrollY])
+
+  useEffect(() => {
+    if (!tracksContainer.current) return
+    const container = tracksContainer.current
+    function handleContainerScroll() {
+      if (isProgrammaticScroll.current) {
+        isProgrammaticScroll.current = false
+        return
+      }
+      setScrollY(container.scrollTop)
+    }
+    container.addEventListener('scroll', handleContainerScroll)
+    return () => container.removeEventListener('scroll', handleContainerScroll)
+  }, [tracksContainer.current])
+
+  useEffect(() => {
     if (!activeSong) return
     setScrollX(() => {
       const cursorPosRawPx = (cursorPos / 60) * activeSong.tempo * 20
@@ -104,19 +147,28 @@ function Sequencer() {
     activeSong && (
       <div className="flex flex-col h-full">
         <Transport />
-        <div className="flex flex-row h-full">
-          <div className="flex flex-col bg-foreground/5 w-48 border-r">
-            <div className="h-5.25 bg-background border-b border-border" />
+        <div className="flex flex-row h-full overflow-hidden">
+          <div
+            ref={tracksContainer}
+            className="relative top-5.25 pb-50 flex flex-col w-48 border-r overflow-y-scroll [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          >
             {trackViews.map((t) => {
               return (
                 <Track
                   key={t.track.id}
+                  id={t.track.id}
                   name={t.track.name}
                   mute={t.track.mute}
                   solo={t.track.solo}
                   volume={t.track.volume}
                   color={t.strokeColor}
                   height={t.height}
+                  inputChannel={t.track.inputChannel ?? -1}
+                  inputStereo={t.track.inputStereo ?? false}
+                  monitoring={t.track.monitoring ?? false}
+                  availableInputs={availableInputs}
+                  onSetInput={setTrackInput}
+                  onSetMonitoring={setTrackMonitoring}
                 />
               )
             })}

--- a/frontend/src/features/sequencer/components/Track.tsx
+++ b/frontend/src/features/sequencer/components/Track.tsx
@@ -2,23 +2,45 @@ import { Button } from '@/shared/shadcn/components/button'
 import { Slider } from '@/shared/shadcn/components/slider'
 import { cn } from '@/shared/shadcn/lib/utils'
 import { getCSSVar } from '../utils'
+import { AudioInput } from '@/shared/models/audio-input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/shadcn/components/select'
 
 type TrackProps = {
+  id: string
   name: string
   mute: boolean
   solo: boolean
   volume: number
   color: string
   height: number
+  inputChannel: number
+  inputStereo: boolean
+  monitoring: boolean
+  availableInputs: AudioInput[]
+  onSetInput: (trackId: string, inputChannel: number, stereo: boolean) => void
+  onSetMonitoring: (trackId: string, monitoring: boolean) => void
 }
 
 function Track({
+  id,
   name,
   mute,
   solo,
   volume,
   color,
   height,
+  inputChannel,
+  inputStereo,
+  monitoring,
+  availableInputs,
+  onSetInput,
+  onSetMonitoring,
 }: Readonly<TrackProps>) {
   function setMute(v: boolean) {
     console.log(v)
@@ -34,7 +56,7 @@ function Track({
 
   return (
     <div
-      className="p-2 pb-4 border-b border-border w-full text-xs flex flex-col gap-2"
+      className="p-2 pb-4 bg-foreground/5 border-b border-border w-full text-xs flex flex-col gap-2"
       style={{
         height: height + 'px',
       }}
@@ -50,7 +72,20 @@ function Track({
           {name}
         </div>
         <div className="flex-1" />
-        <div>
+        <div className="flex gap-0.5">
+          <Button
+            className={cn(
+              'font-bold',
+              monitoring && 'bg-green-500/20 text-green-500',
+            )}
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => onSetMonitoring(id, !monitoring)}
+            disabled={inputChannel === -1}
+            title="Input monitoring"
+          >
+            I
+          </Button>
           <Button
             className={cn(
               'font-bold',
@@ -71,6 +106,42 @@ function Track({
             S
           </Button>
         </div>
+      </div>
+      <div className="flex gap-1 items-center">
+        <Select
+          value={String(inputChannel)}
+          onValueChange={(val) => {
+            onSetInput(id, Number.parseInt(val, 10), inputStereo)
+          }}
+        >
+          <SelectTrigger size="sm" className="flex-1 min-w-0">
+            <SelectValue className="text-xs" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem className="text-xs" value="-1">
+              No Input
+            </SelectItem>
+            {availableInputs.map((input) => (
+              <SelectItem key={input.index} value={String(input.index)}>
+                {input.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {inputChannel >= 0 && (
+          <Button
+            className={cn(
+              'text-[10px] px-1',
+              inputStereo && 'bg-purple-500/20 text-purple-500',
+            )}
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => onSetInput(id, inputChannel, !inputStereo)}
+            title={inputStereo ? 'Stereo input' : 'Mono input'}
+          >
+            {inputStereo ? 'ST' : 'M'}
+          </Button>
+        )}
       </div>
       <div className="p-1 flex gap-1">
         <Slider

--- a/frontend/src/features/sequencer/hooks/useSequencer.tsx
+++ b/frontend/src/features/sequencer/hooks/useSequencer.tsx
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import { getCSSVar } from '../utils'
 import { drawClip } from '../canvas/clips'
 
-export function useSequencer(zoom: number, scrollX: number) {
+export function useSequencer(zoom: number, scrollX: number, scrollY: number) {
   const { activeSong, playheadPos, cursorPos, trackViews } = useProject()
 
   const draw = useCallback(
@@ -21,10 +21,20 @@ export function useSequencer(zoom: number, scrollX: number) {
       for (const [index, trackView] of trackViews.entries()) {
         if (index % 2) {
           ctx.fillStyle = getCSSVar('--track-background-1')
-          ctx.fillRect(0, totalHeight + headerHeight, width, trackView.height)
+          ctx.fillRect(
+            0,
+            totalHeight + headerHeight - scrollY,
+            width,
+            trackView.height,
+          )
         } else {
           ctx.fillStyle = getCSSVar('--track-background-2')
-          ctx.fillRect(0, totalHeight + headerHeight, width, trackView.height)
+          ctx.fillRect(
+            0,
+            totalHeight + headerHeight - scrollY,
+            width,
+            trackView.height,
+          )
         }
 
         if (trackView.track.type === 'AudioFileTrack') {
@@ -32,7 +42,7 @@ export function useSequencer(zoom: number, scrollX: number) {
             const offset = 1.5
             const x =
               (clip.position / 60) * activeSong.tempo * pixelsPerBeat - scrollX
-            const y = totalHeight + headerHeight + offset
+            const y = totalHeight + headerHeight + offset - scrollY
             const width =
               (clip.duration / 60) * activeSong.tempo * pixelsPerBeat
             const height = trackView.height - offset * 2
@@ -64,10 +74,14 @@ export function useSequencer(zoom: number, scrollX: number) {
         pixelsPerLine = pixelsPerSub
       }
 
+      // Header Rect
+      ctx.fillStyle = getCSSVar('--background')
+      ctx.fillRect(0, 0, width, headerHeight)
+
+      // Grid
       const firstVisibleLine = Math.floor(scrollX / pixelsPerLine)
       const lastVisibleLine = Math.ceil((scrollX + width) / pixelsPerLine)
 
-      // Grid
       for (let i = firstVisibleLine; i <= lastVisibleLine; i++) {
         const x = i * pixelsPerLine - scrollX
 
@@ -153,7 +167,7 @@ export function useSequencer(zoom: number, scrollX: number) {
       ctx.lineTo(playheadPosPx, height)
       ctx.stroke()
     },
-    [playheadPos, cursorPos, activeSong, trackViews, zoom, scrollX],
+    [playheadPos, cursorPos, activeSong, trackViews, zoom, scrollX, scrollY],
   )
   return { draw }
 }

--- a/frontend/src/shared/contexts/audio-devices-provider.tsx
+++ b/frontend/src/shared/contexts/audio-devices-provider.tsx
@@ -1,0 +1,96 @@
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { useWebSocket } from './websocket-provider'
+import { AudioDeviceType, AudioDeviceInfo } from '../models/audio-input'
+
+type AudioDevicesProviderState = {
+  deviceTypes: AudioDeviceType[]
+  currentDevice: AudioDeviceInfo | null
+  fetchDevices: () => void
+  setAudioDevice: (
+    deviceType: string,
+    outputDevice: string,
+    inputDevice: string,
+    sampleRate?: number,
+    bufferSize?: number,
+  ) => void
+}
+
+const initialState: AudioDevicesProviderState = {
+  deviceTypes: [],
+  currentDevice: null,
+  fetchDevices: () => null,
+  setAudioDevice: () => null,
+}
+
+const AudioDevicesContext = createContext<AudioDevicesProviderState>(initialState)
+
+export function AudioDevicesProvider({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  const { ws, isConnected, send } = useWebSocket()
+  const [deviceTypes, setDeviceTypes] = useState<AudioDeviceType[]>([])
+  const [currentDevice, setCurrentDevice] = useState<AudioDeviceInfo | null>(
+    null,
+  )
+
+  const fetchDevices = useCallback(() => {
+    if (ws && isConnected) {
+      send({ action: 'audio.listDevices' })
+    }
+  }, [ws, isConnected, send])
+
+  const setAudioDevice = useCallback(
+    (deviceType: string, outputDevice: string, inputDevice: string, sampleRate?: number, bufferSize?: number) => {
+      send({
+        action: 'audio.setDevice',
+        deviceType,
+        outputDevice,
+        inputDevice,
+        ...(sampleRate !== undefined && { sampleRate }),
+        ...(bufferSize !== undefined && { bufferSize }),
+      })
+    },
+    [send],
+  )
+
+  useEffect(() => {
+    if (ws && isConnected) {
+      ws.addEventListener('message', onMessage)
+      send({ action: 'audio.listDevices' })
+      return () => ws.removeEventListener('message', onMessage)
+    }
+  }, [ws, isConnected])
+
+  function onMessage(ev: MessageEvent<unknown>) {
+    if (typeof ev.data !== 'string') return
+    const data = JSON.parse(ev.data)
+    switch (data.event) {
+      case 'audio.devicesList': {
+        if (data.deviceTypes !== undefined) setDeviceTypes(data.deviceTypes)
+        if (data.current !== undefined) setCurrentDevice(data.current)
+        break
+      }
+      case 'audio.deviceChanged': {
+        if (data.current !== undefined) setCurrentDevice(data.current)
+        break
+      }
+    }
+  }
+
+  return (
+    <AudioDevicesContext.Provider
+      value={{ deviceTypes, currentDevice, fetchDevices, setAudioDevice }}
+    >
+      {children}
+    </AudioDevicesContext.Provider>
+  )
+}
+
+export const useAudioDevices = () => {
+  const context = useContext(AudioDevicesContext)
+  if (context === undefined)
+    throw new Error(
+      'useAudioDevices must be used within an AudioDevicesProvider',
+    )
+  return context
+}

--- a/frontend/src/shared/contexts/project-provider.tsx
+++ b/frontend/src/shared/contexts/project-provider.tsx
@@ -1,8 +1,15 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+} from 'react'
 import { Project } from '../models/project'
 import { useWebSocket } from './websocket-provider'
 import { Song } from '../models/song'
 import { Track } from '../models/track'
+import { AudioInput } from '../models/audio-input'
 
 export interface TrackView {
   track: Track
@@ -25,6 +32,14 @@ type ProjectProviderState = {
   playing: boolean
   activeSong: Song | undefined
   trackViews: TrackView[]
+  availableInputs: AudioInput[]
+  setTrackInput: (
+    trackId: string,
+    inputChannel: number,
+    stereo: boolean,
+  ) => void
+  setTrackMonitoring: (trackId: string, monitoring: boolean) => void
+  fetchAudioInputs: () => void
 }
 
 const initialState: ProjectProviderState = {
@@ -35,6 +50,10 @@ const initialState: ProjectProviderState = {
   playing: false,
   activeSong: undefined,
   trackViews: [],
+  availableInputs: [],
+  setTrackInput: () => null,
+  setTrackMonitoring: () => null,
+  fetchAudioInputs: () => null,
 }
 
 const ProjectProviderContext = createContext<ProjectProviderState>(initialState)
@@ -50,14 +69,34 @@ export function ProjectProvider({
   const [cursorPos, setCursorPos] = useState<number>(0)
   const [playing, setPlaying] = useState<boolean>(false)
   const [trackViews, setTrackViews] = useState<TrackView[]>([])
+  const [availableInputs, setAvailableInputs] = useState<AudioInput[]>([])
+
+  const fetchAudioInputs = useCallback(() => {
+    if (ws && isConnected) {
+      send({ action: 'audio.listInputs' })
+    }
+  }, [ws, isConnected, send])
+
+  const setTrackInput = useCallback(
+    (trackId: string, inputChannel: number, stereo: boolean) => {
+      send({ action: 'track.setInput', trackId, inputChannel, stereo })
+    },
+    [send],
+  )
+
+  const setTrackMonitoring = useCallback(
+    (trackId: string, monitoring: boolean) => {
+      send({ action: 'track.setMonitoring', trackId, monitoring })
+    },
+    [send],
+  )
 
   useEffect(() => {
     if (ws && isConnected) {
       ws.addEventListener('message', onMessage)
       try {
-        send({
-          action: 'project.getLoaded',
-        })
+        send({ action: 'project.getLoaded' })
+        send({ action: 'audio.listInputs' })
       } catch (error) {
         console.error(error)
       }
@@ -109,6 +148,40 @@ export function ProjectProvider({
         setPlaying(false)
         break
       }
+      case 'audio.inputsList': {
+        if (data.inputs !== undefined) setAvailableInputs(data.inputs)
+        break
+      }
+      case 'track.inputChanged': {
+        setActiveSong((prev) => {
+          if (!prev) return prev
+          return {
+            ...prev,
+            tracks: prev.tracks.map((t) =>
+              t.id === data.trackId
+                ? {
+                    ...t,
+                    inputChannel: data.inputChannel,
+                    inputStereo: data.stereo,
+                  }
+                : t,
+            ),
+          }
+        })
+        break
+      }
+      case 'track.monitoringChanged': {
+        setActiveSong((prev) => {
+          if (!prev) return prev
+          return {
+            ...prev,
+            tracks: prev.tracks.map((t) =>
+              t.id === data.trackId ? { ...t, monitoring: data.monitoring } : t,
+            ),
+          }
+        })
+        break
+      }
     }
   }
 
@@ -120,7 +193,7 @@ export function ProjectProvider({
         track: t,
         fillColor: `--track-${colorIndex}-fill`,
         strokeColor: `--track-${colorIndex}-stroke`,
-        height: 80,
+        height: 100,
       } satisfies TrackView
       return tv
     })
@@ -137,6 +210,10 @@ export function ProjectProvider({
     playing,
     activeSong,
     trackViews,
+    availableInputs,
+    setTrackInput,
+    setTrackMonitoring,
+    fetchAudioInputs,
   }
 
   return (

--- a/frontend/src/shared/models/audio-input.ts
+++ b/frontend/src/shared/models/audio-input.ts
@@ -1,0 +1,20 @@
+export interface AudioInput {
+  index: number
+  name: string
+}
+
+export interface AudioDeviceType {
+  name: string
+  outputDevices: string[]
+  inputDevices: string[]
+}
+
+export interface AudioDeviceInfo {
+  deviceType: string
+  outputDevice: string
+  inputDevice: string
+  sampleRate: number
+  bufferSize: number
+  availableSampleRates: number[]
+  availableBufferSizes: number[]
+}

--- a/frontend/src/shared/models/track.ts
+++ b/frontend/src/shared/models/track.ts
@@ -16,6 +16,9 @@ export interface BeatTrack {
   mute: boolean
   solo: boolean
   frequency: number
+  inputChannel: number
+  inputStereo: boolean
+  monitoring: boolean
 }
 
 export interface AudioFileTrack {
@@ -27,6 +30,9 @@ export interface AudioFileTrack {
   mute: boolean
   solo: boolean
   clips: Clip[]
+  inputChannel: number
+  inputStereo: boolean
+  monitoring: boolean
 }
 
 export type Track = BeatTrack | AudioFileTrack

--- a/frontend/src/shared/services/websocket/command.ts
+++ b/frontend/src/shared/services/websocket/command.ts
@@ -12,7 +12,11 @@ type TransportCommand =
   | 'transport.setPlayheadPosition'
   | 'transport.setCursorPosition'
 
-type Command = ProjectCommand | TransportCommand
+type AudioCommand = 'audio.listInputs' | 'audio.listDevices' | 'audio.setDevice'
+
+type TrackCommand = 'track.setInput' | 'track.setMonitoring'
+
+type Command = ProjectCommand | TransportCommand | AudioCommand | TrackCommand
 
 export interface WebSocketMessage {
   action: Command

--- a/frontend/src/shared/shadcn/components/label.tsx
+++ b/frontend/src/shared/shadcn/components/label.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/shared/shadcn/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "gap-2 text-xs leading-none group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/frontend/src/shared/shadcn/components/select.tsx
+++ b/frontend/src/shared/shadcn/components/select.tsx
@@ -1,0 +1,184 @@
+import * as React from "react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/shared/shadcn/lib/utils"
+import { IconSelector, IconCheck, IconChevronUp, IconChevronDown } from "@tabler/icons-react"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-none border bg-transparent py-2 pr-2 pl-2.5 text-xs transition-colors select-none focus-visible:ring-1 aria-invalid:ring-1 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-none *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <IconSelector className="text-muted-foreground size-4 pointer-events-none" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        data-align-trigger={position === "item-aligned"}
+        className={cn("bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-none shadow-md ring-1 duration-100 relative z-50 max-h-(--radix-select-content-available-height) origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none", position ==="popper"&&"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1", className )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          data-position={position}
+          className={cn(
+            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
+            position === "popper" && ""
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("text-muted-foreground px-2 py-2 text-xs", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-2 rounded-none py-2 pr-8 pl-2 text-xs [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <IconCheck className="pointer-events-none" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("bg-border -mx-1 h-px pointer-events-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn("bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4", className)}
+      {...props}
+    >
+      <IconChevronUp
+      />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn("bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4", className)}
+      {...props}
+    >
+      <IconChevronDown
+      />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}


### PR DESCRIPTION
  Refactor AudioEngineCore from AudioAppComponent to AudioIODeviceCallback
  with a dedicated AudioDeviceManager for full device control, input channel
  support, and settings persistence.

  Backend:
  - Migrate to AudioIODeviceCallback + AudioDeviceManager (supports 64 input channels)
  - Pre-allocate inputBuffer and mix audio inputs per-track in the audio callback
  - Add monitoring support with atomic track count and pass-through rendering
  - Persist audio device settings to XML (save/load on startup)
  - Propagate sampleRateChanged() to tracks when device settings change
  - Add commands: audio.listDevices, audio.setDevice, audio.listInputs, track.setInput, track.setMonitoring
  - Extend AudioTrack base with inputChannel, inputStereo, monitoring atomics

  Frontend:
  - Add AudioDevicesProvider context (device list, current device, setAudioDevice)
  - Add AudioSettingsDialog (output/input device, sample rate, buffer size)
  - Add AudioInput, AudioDeviceType, AudioDeviceInfo models
  - Extend Track model with inputChannel, inputStereo, monitoring fields
  - Add per-track input selector, mono/stereo toggle, and monitoring button in Track component